### PR TITLE
Made a few changes to how Nginx is setup

### DIFF
--- a/server/nginx/Dockerfile
+++ b/server/nginx/Dockerfile
@@ -1,14 +1,24 @@
 FROM openresty/openresty:alpine-fat
 
+ARG ENTRYPOINT_VERSION=
+#ARG ENTRYPOINT_VERSION=2
+
 EXPOSE 8084
 
 COPY nginx.conf.template /usr/local/openresty/nginx/conf/nginx.conf.template
+
+COPY upstreams*.conf.template /usr/local/openresty/nginx/conf/
+
+#COPY locations*.conf /usr/local/openresty/nginx/conf/
+COPY locations.conf /usr/local/openresty/nginx/conf/
+
+RUN ls
+COPY entrypoint$ENTRYPOINT_VERSION.sh /entrypoint.sh
 
 #COPY sites/*.conf /etc/nginx/sites-enabled/
 
 RUN apk add nano
 
-COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/server/nginx/entrypoint.sh
+++ b/server/nginx/entrypoint.sh
@@ -2,6 +2,8 @@
 
 ldconfig
 
+envsubst '${NGINX_PORT},{$DUMMY_VAR}' < /usr/local/openresty/nginx/conf/nginx.conf.template > /usr/local/openresty/nginx/conf/nginx.conf
+
 envsubst '${NGINX_PORT},\
   ${CROWAPP_IP},${CROWAPP_PORT},\
   ${ASPNETAPP_IP},${ASPNETAPP_PORT},\
@@ -12,7 +14,7 @@ envsubst '${NGINX_PORT},\
   ${SWIFTAPP_IP},${SWIFTAPP_PORT},\
   ${GOAPP_IP},${GOAPP_PORT},\
   ${DUMMY_VAR}'\
-  < /usr/local/openresty/nginx/conf/nginx.conf.template > /usr/local/openresty/nginx/conf/nginx.conf
+  < /usr/local/openresty/nginx/conf/upstreams.conf.template > /usr/local/openresty/nginx/conf/upstreams.conf
 
 /usr/local/openresty/nginx/sbin/nginx -g 'daemon off;'
 while true; do sleep 1d; done

--- a/server/nginx/nginx.conf.template
+++ b/server/nginx/nginx.conf.template
@@ -8,43 +8,15 @@ http {
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*.*;
 
-    upstream crowapp {
-        server ${CROWAPP_IP}:${CROWAPP_PORT};
-    }
-
-    upstream aspnetapp {
-        server ${ASPNETAPP_IP}:${ASPNETAPP_PORT};
-    }
-
-    upstream springbootapp {
-        server ${SPRINGBOOTAPP_IP}:${SPRINGBOOTAPP_PORT};
-    }
-
-    upstream railsapp {
-        server ${RAILSAPP_IP}:${RAILSAPP_PORT};
-    }
-
-    upstream perlapp {
-        server ${PERLAPP_IP}:${PERLAPP_PORT};
-    }
-
-    upstream actixapp {
-        server ${ACTIXAPP_IP}:${ACTIXAPP_PORT};
-    }
-
-    upstream swiftapp {
-        server ${SWIFTAPP_IP}:${SWIFTAPP_PORT};
-    }
-
-    upstream goapp {
-        server ${GOAPP_IP}:${GOAPP_PORT};
-    }
+    include /usr/local/openresty/nginx/conf/upstreams*.conf;
 
     server {
             #root /var/www/html;
 
             listen ${NGINX_PORT};
             server_name localhost 127.0.0.1;
+
+            include /usr/local/openresty/nginx/conf/locations*.conf;
 
             location /tests {
                 location /tests/1 {
@@ -54,78 +26,6 @@ http {
                     add_header Content-Type application/json;
                     return 200 '{"DUMMY_VAR":"${DUMMY_VAR}"}';
                 }
-            }
-
-            location ~ ^/crowapp?(.*)$ {
-                proxy_pass http://crowapp;
-                rewrite /crowapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/aspnetapp?(.*)$ {
-                proxy_pass http://aspnetapp;
-                rewrite /aspnetapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/springbootapp?(.*)$ {
-                proxy_pass http://springbootapp;
-                rewrite /springbootapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/railsapp?(.*)$ {
-                proxy_pass http://railsapp;
-                rewrite /railsapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/perlapp?(.*)$ {
-                proxy_pass http://perlapp;
-                rewrite /perlapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/actixapp?(.*)$ {
-                proxy_pass http://actixapp;
-                rewrite /actixapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/swiftapp?(.*)$ {
-                proxy_pass http://swiftapp;
-                rewrite /swiftapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
-            }
-
-            location ~ ^/goapp?(.*)$ {
-                proxy_pass http://goapp;
-                rewrite /goapp/(.*) /$1 break;
-                proxy_set_header X-Forwarded-For $remote_addr;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header Host $host;
-                proxy_redirect   off;
             }
     }
 }

--- a/server/nginx/upstreams.conf.template
+++ b/server/nginx/upstreams.conf.template
@@ -1,0 +1,35 @@
+upstream crowapp {
+        server ${CROWAPP_IP}:${CROWAPP_PORT};
+    }
+
+upstream aspnetapp {
+    server ${ASPNETAPP_IP}:${ASPNETAPP_PORT};
+}
+
+upstream springbootapp {
+    server ${SPRINGBOOTAPP_IP}:${SPRINGBOOTAPP_PORT};
+}
+
+upstream railsapp {
+    server ${RAILSAPP_IP}:${RAILSAPP_PORT};
+}
+
+upstream perlapp {
+    server ${PERLAPP_IP}:${PERLAPP_PORT};
+}
+
+upstream actixapp {
+    server ${ACTIXAPP_IP}:${ACTIXAPP_PORT};
+}
+
+upstream swiftapp {
+    server ${SWIFTAPP_IP}:${SWIFTAPP_PORT};
+}
+
+upstream goapp {
+    server ${GOAPP_IP}:${GOAPP_PORT};
+}
+
+upstream bunapp {
+    server ${BUNAPP_IP}:${BUNAPP_PORT};
+}


### PR DESCRIPTION
The reasons for this include:
1. **Separation of concerns**: The upstream definitions are now separated from the location definitions.
2. **Extensibility**: One can now add more upstream or location definition files as desired, if, say, they want to either separate by some kind of arbitrary category; or, if they perhaps want to test one cluster of sites at once but not the others.

In the future, I hope to use such a mechanism, or something similar, to implement techniques such as A/B testing, or perhaps various load balancing algorithms.