### PR TITLE
Nginx v2 option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,17 @@ redis-set-variable:
 
 
 nginx-build:
-	cd server/nginx && docker build --build-arg NGINX_VERSION=$(NGINX_VERSION) --build-arg LUA_JIT_VERSION=$(LUA_JIT_VERSION) -t nginx:latest .
+	cd server/nginx && docker build --build-arg NGINX_VERSION=$(NGINX_VERSION) --build-arg LUA_JIT_VERSION=$(LUA_JIT_VERSION) --build-arg NGINX_PORT=$(NGINX_PORT) -t nginx:latest .
 
 nginx-run:
-	docker run -it --name nginx -p $(NGINX_PORT):$(NGINX_PORT) --env-file ".env" --net $(SUBNET_NAME) -v $(NGINX_DIR):/usr/share/nginx/html --ip $(NGINX_IP) -d nginx:latest
+	docker run -it --name nginx -p $(NGINX_PORT):$(NGINX_PORT) --env-file ".env" --env NGINX_PORT=$(NGINX_PORT) --net $(SUBNET_NAME) -v $(NGINX_DIR):/usr/share/nginx/html --ip $(NGINX_IP) -d nginx:latest
+
+
+nginx-v2-build:
+	cd server/nginx && docker build --build-arg NGINX_VERSION=$(NGINX_VERSION) --build-arg LUA_JIT_VERSION=$(LUA_JIT_VERSION) --build-arg ENTRYPOINT_VERSION=2 --build-arg NGINX_PORT=$(NGINX_PORT) --build-arg LOCATIONS="-more" -t nginx-v2:latest .
+
+nginx-v2-run:
+	docker run -it --name nginx-v2 -p $(NGINX_PORT):$(NGINX_PORT) --env-file ".env" --env ENTRYPOINT_VERSION=2 --env NGINX_PORT=$(NGINX_PORT) --env LOCATIONS="-more" --net $(SUBNET_NAME) -v $(NGINX_DIR):/usr/share/nginx/html --ip $(NGINX_IP) -d nginx-v2:latest
 
 
 # Note: "-s -C ." are to suppress the "Entering directory" and "Leaving directory" messages.

--- a/README.md
+++ b/README.md
@@ -218,3 +218,38 @@ Does NOT work (`exec form`): `ENTRYPOINT ["dotnet", "aspnetapp.dll", "--urls", $
 DOES work (`shell form`): `ENTRYPOINT dotnet aspnetapp.dll --urls $URL`
 
 Refer to: https://stackoverflow.com/questions/37904682/how-do-i-use-docker-environment-variable-in-entrypoint-array
+
+### Make Gotchas
+
+#### Tabs vs Spaces
+
+Makefiles require tabs and will throw an error if you use spaces instead.
+
+For instance, the following will throw an error:
+
+**Makefile**:
+```shell
+nginx-v2-build:
+    cd server/nginx-v2 && docker build --build-arg NGINX_VERSION=$(NGINX_VERSION) --build-arg LUA_JIT_VERSION=$(LUA_JIT_VERSION) --build-arg ENTRYPOINT_VERSION=2 --build-arg NGINX_PORT=$(NGINX_PORT) -t nginx-v2:latest .
+```
+
+**Error**:
+```shell
+(venv) PS C:\Users\Darren\PycharmProjects\Miniprojects\RESTettaStone> make nginx-v2-build
+Makefile:43: *** multiple target patterns.  Stop.
+```
+
+Whereas this next snippet will work just fine:
+
+```shell
+nginx-v2-build:
+	cd server/nginx-v2 && docker build --build-arg NGINX_VERSION=$(NGINX_VERSION) --build-arg LUA_JIT_VERSION=$(LUA_JIT_VERSION) --build-arg ENTRYPOINT_VERSION=2 --build-arg NGINX_PORT=$(NGINX_PORT) -t nginx-v2:latest .
+```
+
+So Makefiles are picky about this... so what, right?
+
+It's the completely ambiguous error message that makes this particularly frustrating.
+
+The message *"multiple target patterns"* seems to indicate another root cause altogether, so if you don't already associate that error in your mind with a case of using the wrong whitespace for indentation, it can be perplexing indeed.
+
+Just something to keep in mind.

--- a/server/nginx/Dockerfile
+++ b/server/nginx/Dockerfile
@@ -14,11 +14,9 @@ COPY upstreams*.conf.template /usr/local/openresty/nginx/conf/
 COPY locations.conf /usr/local/openresty/nginx/conf/
 COPY locations$LOCATIONS.conf /usr/local/openresty/nginx/conf/
 
-RUN ls
 COPY entrypoint$ENTRYPOINT_VERSION.sh /entrypoint.sh
 
-#COPY sites/*.conf /etc/nginx/sites-enabled/
-
+# For debugging inside the container:
 RUN apk add nano
 
 RUN chmod +x /entrypoint.sh

--- a/server/nginx/Dockerfile
+++ b/server/nginx/Dockerfile
@@ -1,16 +1,18 @@
 FROM openresty/openresty:alpine-fat
 
+ARG NGINX_PORT
 ARG ENTRYPOINT_VERSION=
-#ARG ENTRYPOINT_VERSION=2
 
-EXPOSE 8084
+ARG LOCATIONS=
+
+EXPOSE $NGINX_PORT
 
 COPY nginx.conf.template /usr/local/openresty/nginx/conf/nginx.conf.template
 
 COPY upstreams*.conf.template /usr/local/openresty/nginx/conf/
 
-#COPY locations*.conf /usr/local/openresty/nginx/conf/
 COPY locations.conf /usr/local/openresty/nginx/conf/
+COPY locations$LOCATIONS.conf /usr/local/openresty/nginx/conf/
 
 RUN ls
 COPY entrypoint$ENTRYPOINT_VERSION.sh /entrypoint.sh


### PR DESCRIPTION
Added the capabilities for additional alternative Nginx container versions.

The primary purpose for this, for myself at the moment at least, is to allow me to test other sub project apps while another one is being staged for a PR.