### PR TITLE
Full CRUD testing suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ prometheus:
 
 
 run-tests:
-	source $(PYTHON_BIN)activate && $(PYTHON_BIN)python other/tests/main.py $(NGINX_HOST) $(NGINX_PORT)
+	source $(PYTHON_BIN)activate && $(PYTHON_BIN)python main.py tests $(NGINX_HOST) $(NGINX_PORT)
 
 
 visuals:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,10 @@
+import sys
+print(sys.argv)
+
+if len(sys.argv) < 2:
+    print("Please provide a minimum of one argument.")
+    sys.exit(1)
+
+if sys.argv[1] == 'tests':
+    from other.tests.main import run_tests
+    run_tests()

--- a/other/populate_pg_db.py
+++ b/other/populate_pg_db.py
@@ -36,19 +36,19 @@ def drop_table(table_name: str):
         connection.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
         connection.commit()
 
-try:
-    create_table('users')
-except Exception as e:
-    print(e)
-    if 'psycopg2.errors.DuplicateTable' in str(e):
-        print('Table already exists... Dropping...')
-        drop_table('users')
-        create_table('users')
 
 def add_user(name: str, email: str):
     insert_data('users', name, email)
 
 def add_users():
+    try:
+        create_table('users')
+    except Exception as e:
+        print(e)
+        if 'psycopg2.errors.DuplicateTable' in str(e):
+            print('Table already exists... Dropping...')
+            drop_table('users')
+            create_table('users')
     try:
         pg_data = json.loads(open('other/pg_data.json').read())
     except FileNotFoundError:
@@ -61,4 +61,6 @@ def add_users():
     for user in pg_data:
         add_user(user['name'], user['email'])
 
-add_users()
+if __name__ == '__main__':
+    print("ADDING USERS")
+    add_users()

--- a/other/tests/main.py
+++ b/other/tests/main.py
@@ -46,12 +46,14 @@ def run_tests():
 
     args = sys.argv
 
-    if len(args) != 3:
+    if len(args) != 4:
         print("\x1b[31;1m"+"Please provide the host and port of the nginx server."+"\x1b[0m")
         return
 
-    nginx_host = args[1]
-    nginx_port = int(args[2])
+    nginx_host = args[2]
+    nginx_port = int(args[3])
+
+    print("\x1b[32;20m"+"Running tests..."+f"Nginx host: {nginx_host}. Nginx port: {nginx_port}."+"\x1b[0m")
 
     _id = 1
 

--- a/other/tests/main.py
+++ b/other/tests/main.py
@@ -4,6 +4,8 @@ import enum
 import time
 import requests
 
+from other.populate_pg_db import create_table, drop_table
+
 
 class HTTP(enum.Enum):
     GET = 'GET'
@@ -142,7 +144,15 @@ def run_tests():
             'vibeapp',
             'zigapp'
         ]:
+        print("\x1b[32;20m"+f"Testing {app}..."+'\x1b[0m')
+        print("\x1b[32;20m"+"Dropping table (users)"+'\x1b[0m')
+        drop_table('users')
+        print("\x1b[32;20m"+"Creating table (users)"+'\x1b[0m')
+        create_table('users')
+
         for test in tests:
+            print("\x1b[32;20m"+f"Testing {test.endpoint} ({test.method})..."+'\x1b[0m')
+
             time.sleep(DELAY_TIME)
             test.name = app
             try:

--- a/other/tests/main.py
+++ b/other/tests/main.py
@@ -20,17 +20,21 @@ class HTTP(enum.Enum):
 
 
 class Tester:
-    def __init__(self, host: str, port: int, name: str, endpoint: str, method: HTTP, assertions: callable):
+    def __init__(self, host: str, port: int, name: str, endpoint: str, method: HTTP, assertions: callable, data: dict = None):
         self.host = host
         self.port = port
         self.name = name
         self.endpoint = endpoint
         self.method = method
         self.assertions = assertions
+        self.data = data
 
     def test(self):
         url = f'http://{self.host}:{self.port}/{self.name}{self.endpoint}'
-        r = requests.request(self.method, url)
+        if self.data:
+            r = requests.request(self.method, url, json=self.data)
+        else:
+            r = requests.request(self.method, url)
         for assertion in self.assertions:
             if not assertion(r): return False
         return True
@@ -46,25 +50,85 @@ def run_tests():
     nginx_host = args[1]
     nginx_port = int(args[2])
 
+    _id = 1
+
     endpoint = '/users'
     method = HTTP.GET
     assertions = [lambda r: r.status_code == 200, lambda r: r.json()[0].get('email') == 'test_email1@testing.com']
+    data = None
+
+    test_get_many = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    endpoint = '/users'
+    method = HTTP.GET
+    assertions = [lambda r: r.status_code == 200, lambda r: r.json()[0].get('email') == 'test_email1@testing.com']
+    data = None
+
+    test_get_one = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    endpoint = '/users'
+    method = HTTP.POST
+    assertions = [lambda r: r.status_code == 200]
+    data = {'email': 'test_email1@testing.com'}
+
+    test_post = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    endpoint = f'/users/{_id}'
+    method = HTTP.PUT
+    assertions = [lambda r: r.status_code == 200]
+    data = {'email': 'test_email1b@testing.com'}
+
+    test_update = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    endpoint = f'/users/{_id}'
+    method = HTTP.PUT
+    assertions = [lambda r: r.status_code == 404]
+    data = {'email': 'test_email1b@testing.com'}
+
+    test_update_not_found = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    endpoint = f'/users/{_id}'
+    method = HTTP.DELETE
+    assertions = [lambda r: r.status_code == 200]
+    data = None
+
+    test_delete = Tester(host=nginx_host, port=nginx_port, name='', endpoint=endpoint, method=method, assertions=assertions, data=data)
+
+    tests = [
+        # This order is logical for the above tests...
+        # We first POST one in order to create an initial user for the next few tests.
+        # Then we test GET one and GET many to ensure that the user was created.
+        # Then we test PUT to update the user.
+        # Then we test DELETE to delete the user.
+        # Then we test PUT again but with the recently deleted user to ensure that the user is not found.
+        # NOTE that this requires a freshly cleaned database.
+        test_post,
+        test_get_one,
+        test_get_many,
+        test_update,
+        test_delete,
+        test_update_not_found
+    ]
 
     for app in [
-            'actixapp', 'aspnetapp', 'bunapp', 'crowapp', 'djangoapp',
-            'fatfreeapp', 'firebaseapp', 'flaskapp', 'fsharpapp', 'goapp',
-            'laravelapp', 'luaapp', 'nodeapp', 'perlapp', 'phpapp', 'playapp',
-            'prologapp', 'railsapp', 'rocketapp', 'springbootapp', 'swiftapp',
-            'symfonyapp', 'tomcatapp', 'vibeapp', 'zigapp'
+            #'actixapp', 'aspnetapp', 'bunapp', 'crowapp', 'djangoapp',
+            #'fatfreeapp', 'firebaseapp', 'flaskapp', 'fsharpapp', 'goapp',
+            #'laravelapp', 'luaapp', 'nodeapp', 'perlapp', 'phpapp', 'playapp',
+            #'prologapp', 'railsapp', 'rocketapp', 'springbootapp', 'swiftapp',
+            #'symfonyapp', 'tomcatapp', 'vibeapp', 'zigapp'
+            'flaskapp'
         ]:
-        tester = Tester(host=nginx_host, port=nginx_port, name=app, endpoint=endpoint, method=method, assertions=assertions)
-        try:
-            assert tester.test()
-            print("\x1b[32;20m"+f"{app} test passed for endpoint {endpoint} ({method})."+'\x1b[0m')
-        except AssertionError:
-            print("\x1b[31;1m"+f"{app} test failed for endpoint {endpoint} ({method})."+"\x1b[0m")
-        except KeyError:
-            print("\x1b[31;1m"+f"{app} test failed [KEY ERROR] for endpoint {endpoint} ({method})."+"\x1b[0m")
+        for test in tests:
+            import time
+            time.sleep(5)
+            test.name = app
+            try:
+                assert test.test()
+                print("\x1b[32;20m"+f"{app} test passed for endpoint {test.endpoint} ({test.method})."+'\x1b[0m')
+            except AssertionError:
+                print("\x1b[31;1m"+f"{app} test failed for endpoint {test.endpoint} ({test.method})."+"\x1b[0m")
+            except KeyError:
+                print("\x1b[31;1m"+f"{app} test failed [KEY ERROR] for endpoint {test.endpoint} ({test.method})."+"\x1b[0m")
 
 
 if __name__ == '__main__':

--- a/other/tests/main.py
+++ b/other/tests/main.py
@@ -1,6 +1,7 @@
 """"""
 import sys
 import enum
+import time
 import requests
 
 
@@ -41,6 +42,8 @@ class Tester:
 
 
 def run_tests():
+    DELAY_TIME = 0.1
+
     args = sys.argv
 
     if len(args) != 3:
@@ -138,8 +141,7 @@ def run_tests():
             'zigapp'
         ]:
         for test in tests:
-            import time
-            time.sleep(5)
+            time.sleep(DELAY_TIME)
             test.name = app
             try:
                 assert test.test()

--- a/other/tests/main.py
+++ b/other/tests/main.py
@@ -111,12 +111,31 @@ def run_tests():
     ]
 
     for app in [
-            #'actixapp', 'aspnetapp', 'bunapp', 'crowapp', 'djangoapp',
-            #'fatfreeapp', 'firebaseapp', 'flaskapp', 'fsharpapp', 'goapp',
-            #'laravelapp', 'luaapp', 'nodeapp', 'perlapp', 'phpapp', 'playapp',
-            #'prologapp', 'railsapp', 'rocketapp', 'springbootapp', 'swiftapp',
-            #'symfonyapp', 'tomcatapp', 'vibeapp', 'zigapp'
-            'flaskapp'
+            'actixapp',
+            'aspnetapp',
+            'bunapp',
+            'crowapp',
+            'djangoapp',
+            'fatfreeapp',
+            'firebaseapp',
+            'flaskapp',
+            'fsharpapp',
+            'goapp',
+            'laravelapp',
+            'luaapp',
+            'nodeapp',
+            'perlapp',
+            'phpapp',
+            'playapp',
+            'prologapp',
+            'railsapp',
+            'rocketapp',
+            'springbootapp',
+            'swiftapp',
+            'symfonyapp',
+            'tomcatapp',
+            'vibeapp',
+            'zigapp'
         ]:
         for test in tests:
             import time


### PR DESCRIPTION
This PR expands on our existing universal testing code for testing all of the individual sub projects in our repo.

We can now test various different operations among the Create, Read, Update, and Destroy spectrum.

There is also a mechanism built in to clear the `users` table in the Postgres database in between app tests, since all apps point to the same database (which of course, in our case here, is by design).

This PR required some slight modifications to how we run any of our utility Python scripts from the `Makefile`.

I also added a new Gotcha to the README about `pg_stat_activity` locking and how to fix it.
